### PR TITLE
Small changes to how dependencies are installed in workflows. 

### DIFF
--- a/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/agent_deployment/model_serving/notebooks/ModelServing.py.tmpl
+++ b/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/agent_deployment/model_serving/notebooks/ModelServing.py.tmpl
@@ -17,18 +17,20 @@
 # * uc_catalog (required)           - Name of the Unity Catalog 
 # * schema (required)               - Name of the schema inside Unity Catalog 
 # * registered_model (required)     - Name of the model registered in mlflow
-# * model_version (required)        - Model verison to deploy
+# * model_alias (required)          - Model alias to deploy
 # * scale_to_zero (required)        - Specify if the endpoint should scale to zero when not in use.
 # * workload_size (required)        - Specify  the size of the compute scale out that corresponds with the number of requests this served 
 #                                     model can process at the same time. This number should be roughly equal to QPS x model run time.
+# * bundle_root (required)          - Root of the bundle
 #
 # Widgets:
 # * Unity Catalog: Text widget to input the name of the Unity Catalog
 # * Schema: Text widget to input the name of the database inside the Unity Catalog
 # * Registered model name: Text widget to input the name of the model to register in mlflow
-# * Model Vesion: Text widget to input the model version to deploy
+# * Model Alias: Text widget to input the model alias to deploy
 # * Scale to zero: Whether the clusters should scale to zero (requiring more time at startup after inactivity)
 # * Workload Size: Compute that matches estimated number of requests for the endpoint
+# * Bundle root: Text widget to input the root of the bundle
 #
 # Usage:
 # 1. Set the appropriate values for the widgets.
@@ -36,10 +38,6 @@
 # 3. Run to deploy endpoint.
 #
 ##################################################################################
-
-# COMMAND ----------
-
-# MAGIC %pip install -qqqq databricks-agents==1.1.0 mlflow==3.1.1
 
 # COMMAND ----------
 
@@ -75,6 +73,13 @@ dbutils.widgets.dropdown("scale_to_zero", "True", ["True", "False"], "Scale to z
 # Workdload size
 dbutils.widgets.dropdown("workload_size", "Small", ["Small", "Medium", "Large"], "Workload Size")
 
+# Bundle root
+dbutils.widgets.text(
+    "bundle_root",
+    "/",
+    label="Root of bundle",
+)
+
 # COMMAND ----------
 
 dbutils.library.restartPython()
@@ -87,6 +92,7 @@ registered_model = dbutils.widgets.get("registered_model")
 model_alias = dbutils.widgets.get("model_alias")
 scale_to_zero = bool(dbutils.widgets.get("scale_to_zero"))
 workload_size = dbutils.widgets.get("workload_size")
+bundle_root = dbutils.widgets.get("bundle_root")
 
 assert uc_catalog != "", "uc_catalog notebook parameter must be specified"
 assert schema != "", "schema notebook parameter must be specified"
@@ -94,13 +100,13 @@ assert registered_model != "", "registered_model notebook parameter must be spec
 assert model_alias != "", "model_alias notebook parameter must be specified"
 assert scale_to_zero != "", "scale_to_zero notebook parameter must be specified"
 assert workload_size != "", "workload_size notebook parameter must be specified"
+assert bundle_root != "", "bundle_root notebook parameter must be specified"
 
-# COMMAND ----------
+# Updating to bundle root
+import sys 
 
-import os
-notebook_path =  '/Workspace/' + os.path.dirname(dbutils.notebook.entry_point.getDbutils().notebook().getContext().notebookPath().get())
-%cd $notebook_path
-%cd ../serving
+root = dbutils.widgets.get("bundle_root")
+sys.path.append(root)
 
 # COMMAND ----------
 # DBTITLE 1,Review Instructions
@@ -148,7 +154,7 @@ agents.set_review_instructions(model_name, instructions_to_reviewer)
 # DBTITLE 1, Wait for model serving endpoint to be ready
 
 # DBTITLE 1,Test Endpoint
-from serving import wait_for_model_serving_endpoint_to_be_ready
+from agent_deployment.model_serving.serving import wait_for_model_serving_endpoint_to_be_ready
 wait_for_model_serving_endpoint_to_be_ready(deployment_info.endpoint_name)
 
 # COMMAND ----------

--- a/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/agent_deployment/model_serving/serving/__init__.py.tmpl
+++ b/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/agent_deployment/model_serving/serving/__init__.py.tmpl
@@ -1,0 +1,7 @@
+"""Model serving utilities for agent deployment."""
+
+from .serving import wait_for_model_serving_endpoint_to_be_ready
+
+__all__ = [
+    "wait_for_model_serving_endpoint_to_be_ready",
+]

--- a/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/agent_deployment/model_serving/serving/serving.py.tmpl
+++ b/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/agent_deployment/model_serving/serving/serving.py.tmpl
@@ -1,8 +1,3 @@
-import sys
-import pathlib
-
-sys.path.append(str(pathlib.Path(__file__).parent.parent.parent.resolve()))
-
 def wait_for_model_serving_endpoint_to_be_ready(ep_name):
     from databricks.sdk import WorkspaceClient
     from databricks.sdk.service.serving import EndpointStateReady, EndpointStateConfigUpdate
@@ -23,7 +18,3 @@ def wait_for_model_serving_endpoint_to_be_ready(ep_name):
         else:
           break
     raise Exception(f"Couldn't start the endpoint, timeout, please check your endpoint for more details: {state}")
-
-
-if __name__ == "__main__":
-    wait_for_model_serving_endpoint_to_be_ready(ep_name=sys.argv[1])

--- a/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/agent_development/agent/notebooks/Agent.py.tmpl
+++ b/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/agent_development/agent/notebooks/Agent.py.tmpl
@@ -21,6 +21,8 @@
 # * experiment (required)                     - Name of the experiment to register the run under
 # * registered_model (required)               - Name of the model to register in mlflow
 # * max_words (required)                      - Maximum number of words to return in the response
+# * model_alias (required)                    - Alias to give to newly registered model
+# * bundle_root (required)                    - Root of the bundle
 #
 # Widgets:
 # * Unity Catalog: Text widget to input the name of the Unity Catalog
@@ -31,16 +33,14 @@
 # * Experiment: Text widget to input the name of the experiment to register the run under
 # * Registered model name: Text widget to input the name of the model to register in mlflow
 # * Max words: Text widget to input the maximum integer number of words to return in the response
+# * Model Alias: Text widget to input the alias of the model to register in mlflow
+# * Bundle root: Text widget to input the root of the bundle
 #
 # Usage:
 # 1. Set the appropriate values for the widgets.
 # 2. Run the pipeline to create and register an agent with tool calling.
 #
 ##################################################################################
-
-# COMMAND ----------
-
-# MAGIC %pip install -qqqq -r ../../agent_requirements.txt
 
 # COMMAND ----------
 
@@ -102,16 +102,12 @@ dbutils.widgets.text(
     label="Model Alias",
 )
 
-# COMMAND ----------
-
-dbutils.library.restartPython()
-
-# COMMAND ----------
-
-import os
-notebook_path =  '/Workspace/' + os.path.dirname(dbutils.notebook.entry_point.getDbutils().notebook().getContext().notebookPath().get())
-%cd $notebook_path
-%cd ../tools
+# Bundle root
+dbutils.widgets.text(
+    "bundle_root",
+    "/",
+    label="Root of bundle",
+)
 
 # COMMAND ----------
 
@@ -124,6 +120,7 @@ experiment = dbutils.widgets.get("experiment")
 registered_model = dbutils.widgets.get("registered_model")
 max_words = dbutils.widgets.get("max_words")
 model_alias = dbutils.widgets.get("model_alias")
+bundle_root = dbutils.widgets.get("bundle_root")
 
 assert uc_catalog != "", "uc_catalog notebook parameter must be specified"
 assert schema != "", "schema notebook parameter must be specified"
@@ -134,6 +131,11 @@ assert experiment != "", "experiment notebook parameter must be specified"
 assert registered_model != "", "registered_model notebook parameter must be specified"
 assert max_words != "", "max_words notebook parameter must be specified"
 assert model_alias != "", "model_alias notebook parameter must be specified"
+assert bundle_root != "", "bundle_root notebook parameter must be specified"
+
+# Updating to bundle root
+import sys 
+sys.path.append(bundle_root)
 
 # COMMAND ----------
 
@@ -150,7 +152,7 @@ set_uc_function_client(client)
 # COMMAND ----------
 
 # DBTITLE 1,Function: execute_python_code
-from ai_tools import execute_python_code
+from agent_development.agent.tools import execute_python_code
 
 function_info = client.create_python_function(
     func=execute_python_code, catalog=uc_catalog, schema=schema, replace=True
@@ -163,7 +165,7 @@ client.execute_function(python_execution_function_name, {"code": "print(1+1)"})
 # COMMAND ----------
 
 # DBTITLE 1,Function: ai_function_name_sql
-from ai_tools import ask_ai_function
+from agent_development.agent.tools import ask_ai_function
 
 ask_ai_function_name = f"{uc_catalog}.{schema}.ask_ai"
 
@@ -174,7 +176,7 @@ result.value
 # COMMAND ----------
 
 # DBTITLE 1,Function: summarization_function
-from ai_tools import summarization_function
+from agent_development.agent.tools import summarization_function
 
 summarization_function_name = f"{uc_catalog}.{schema}.summarize"
 
@@ -185,7 +187,7 @@ client.execute_function(summarization_function_name, {"text": result.value, "max
 # COMMAND ----------
 
 # DBTITLE 1,Function: translate_function
-from ai_tools import translate_function
+from agent_development.agent.tools import translate_function
 
 translate_function_name = f"{uc_catalog}.{schema}.translate"
 
@@ -364,7 +366,7 @@ final_state["messages"][-1].get('content')
 # COMMAND ----------
 
 # DBTITLE 1,Log the model using MLflow
-# MAGIC %%writefile ../notebooks/app.py
+# MAGIC %%writefile app.py
 # MAGIC from typing import Any, Generator, Optional, Sequence, Union, Literal
 # MAGIC import mlflow
 # MAGIC from databricks_langchain import (

--- a/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/agent_development/agent/tools/ai_tools.py.tmpl
+++ b/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/agent_development/agent/tools/ai_tools.py.tmpl
@@ -14,8 +14,18 @@ def execute_python_code(code: str) -> str:
 
     stdout = StringIO()
     sys.stdout = stdout
-    exec(code)
-    return stdout.getvalue()
+    try: 
+        exec(code)
+        return stdout.getvalue()
+    except Exception as e:
+        if "Spark" in str(e): 
+            return f"Python code execution failed: {e}. Databricks specific code is not allowed." 
+        if "pyspark" in str(e):
+            return f"Python code execution failed: {e}. Databricks specific code is not allowed." 
+        if "dbutils" in str(e): 
+            return f"Python code execution failed: {e}. Databricks specific code is not allowed." 
+        else:
+            return f"Python code execution failed: {e}. Use simple code + try again."
 
 # AI function name
 ask_ai_function = """CREATE OR REPLACE FUNCTION {ask_ai_function_name}(question STRING COMMENT 'question to ask')

--- a/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/agent_development/agent_evaluation/evaluation/__init__.py.tmpl
+++ b/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/agent_development/agent_evaluation/evaluation/__init__.py.tmpl
@@ -1,0 +1,9 @@
+"""Evaluation module for agent evaluation."""
+
+from .evaluation import (
+    get_reference_documentation
+)
+
+__all__ = [
+    "get_reference_documentation",
+]

--- a/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/agent_development/agent_evaluation/notebooks/AgentEvaluation.py.tmpl
+++ b/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/agent_development/agent_evaluation/notebooks/AgentEvaluation.py.tmpl
@@ -18,7 +18,8 @@
 # * eval_table (required)           - Name of the table containing the evaluation dataset
 # * experiment (required)           - Name of the experiment to register the run under
 # * registered_model (required)     - Name of the model registered in mlflow
-# * model_version (required)        - Model verison to deploy
+# * model_alias (required)          - Model alias to deploy
+# * bundle_root (required)          - Root of the bundle
 #
 # Widgets:
 # * Unity Catalog: Text widget to input the name of the Unity Catalog
@@ -26,17 +27,14 @@
 # * Evaluation Table: Text widget to input the name of the table containing the evaluation dataset
 # * Experiment: Text widget to input the name of the experiment to register the run under
 # * Registered model name: Text widget to input the name of the model to register in mlflow
-# * Model Vesion: Text widget to input the model version to deploy
+# * Model Alias: Text widget to input the model alias to deploy
+# * Bundle root: Text widget to input the root of the bundle
 #
 # Usage:
 # 1. Set the appropriate values for the widgets.
 # 2. Run to evaluate your agent.
 #
 ##################################################################################
-
-# COMMAND ----------
-
-# MAGIC %pip install -qqqq -r ../../agent_requirements.txt
 
 # COMMAND ----------
 
@@ -79,10 +77,12 @@ dbutils.widgets.text(
     "agent_latest",
     label="Model Alias",
 )
-
-# COMMAND ----------
-
-dbutils.library.restartPython()
+# Bundle root
+dbutils.widgets.text(
+    "bundle_root",
+    "/",
+    label="Root of bundle",
+)
 
 # COMMAND ----------
 
@@ -92,6 +92,7 @@ eval_table = dbutils.widgets.get("eval_table")
 experiment = dbutils.widgets.get("experiment")
 registered_model = dbutils.widgets.get("registered_model")
 model_alias = dbutils.widgets.get("model_alias")
+bundle_root = dbutils.widgets.get("bundle_root")
 
 assert uc_catalog != "", "uc_catalog notebook parameter must be specified"
 assert schema != "", "schema notebook parameter must be specified"
@@ -99,15 +100,7 @@ assert eval_table != "", "eval_table notebook parameter must be specified"
 assert experiment != "", "experiment notebook parameter must be specified"
 assert registered_model != "", "registered_model notebook parameter must be specified"
 assert model_alias != "", "model_alias notebook parameter must be specified"
-
-
-# COMMAND ----------
-
-import os
-
-notebook_path =  '/Workspace/' + os.path.dirname(dbutils.notebook.entry_point.getDbutils().notebook().getContext().notebookPath().get())
-%cd $notebook_path
-%cd ../evaluation
+assert bundle_root != "", "bundle_root notebook parameter must be specified"
 
 # COMMAND ----------
 
@@ -129,7 +122,7 @@ print(f"Evaluation dataset: {uc_catalog}.{schema}.{eval_table}")
 # COMMAND ----------
 
 # DBTITLE 1,Get Reference Documentation
-from evaluation import get_reference_documentation
+from agent_development.agent_evaluation.evaluation import get_reference_documentation
 
 reference_docs = get_reference_documentation(uc_catalog, schema, eval_table, spark)
 

--- a/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/data_preparation/data_ingestion/notebooks/DataIngestion.py.tmpl
+++ b/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/data_preparation/data_ingestion/notebooks/DataIngestion.py.tmpl
@@ -17,22 +17,20 @@
 # * schema (required)                         - Name of the schema inside the Unity Catalog
 # * raw_data_table (required)                 - Name of the raw data table inside the database of the Unity Catalog
 # * data_source_url (required)                - URL of the data source. Default is "https://docs.databricks.com/en/doc-sitemap.xml"
+# * bundle_root (required)                    - Root of the bundle
 #
 # Widgets:
 # * Unity Catalog: Text widget to input the name of the Unity Catalog
 # * Schema: Text widget to input the name of the database inside the Unity Catalog
 # * Raw data table: Text widget to input the name of the raw data table inside the database of the Unity Catalog
 # * Data Source URL: Text widget to input the URL of the data source
+# * Root of bundle: Text widget to input the root of the bundle
 #
 # Usage:
 # 1. Set the appropriate values for the widgets.
 # 2. Run the pipeline to collect and store the raw documentation data.
 #
 ##################################################################################
-
-# COMMAND ----------
-
-# MAGIC %pip install -qqqq -r ../../../requirements.txt
 
 # COMMAND ----------
 
@@ -66,6 +64,13 @@ dbutils.widgets.text(
     label="Data Source URL",
 )
 
+# Bundle root
+dbutils.widgets.text(
+    "bundle_root",
+    "/",
+    label="Root of bundle",
+)
+
 # COMMAND ----------
 
 # DBTITLE 1,Define input and output variables
@@ -73,20 +78,19 @@ uc_catalog = dbutils.widgets.get("uc_catalog")
 schema = dbutils.widgets.get("schema")
 raw_data_table = dbutils.widgets.get("raw_data_table")
 data_source_url = dbutils.widgets.get("data_source_url")
+bundle_root = dbutils.widgets.get("bundle_root")
 
 assert uc_catalog != "", "uc_catalog notebook parameter must be specified"
 assert schema != "", "schema notebook parameter must be specified"
 assert raw_data_table != "", "raw_data_table notebook parameter must be specified"
 assert data_source_url != "", "data_source_url notebook parameter must be specified"
+assert bundle_root != "", "bundle_root notebook parameter must be specified"
 
-# COMMAND ----------
+# Updating to bundle root
+import sys 
 
-# DBTITLE 1,Get notebook path
-import os
-
-notebook_path =  '/Workspace/' + os.path.dirname(dbutils.notebook.entry_point.getDbutils().notebook().getContext().notebookPath().get())
-%cd $notebook_path
-%cd ../ingestion
+root = dbutils.widgets.get("bundle_root")
+sys.path.append(root)
 
 # COMMAND ----------
 
@@ -98,7 +102,7 @@ spark.sql(f"""USE `{uc_catalog}`.`{schema}`""")
 # COMMAND ----------
 
 # DBTITLE 1,Download and store data to UC
-from fetch_data import fetch_data_from_url
+from data_preparation.data_ingestion.ingestion.fetch_data import fetch_data_from_url
 
 if not spark.catalog.tableExists(f"{raw_data_table}") or spark.table(f"{raw_data_table}").isEmpty():
     # Download the data to a DataFrame 

--- a/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/data_preparation/data_preprocessing/notebooks/DataPreprocessing.py.tmpl
+++ b/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/data_preparation/data_preprocessing/notebooks/DataPreprocessing.py.tmpl
@@ -22,6 +22,7 @@
 # * max_chunk_size (optional)                 - Maximum chunk size
 # * min_chunk_size (optional)                 - Minimum chunk size
 # * chunk_overlap (optional)                  - Overlap between chunks 
+# * bundle_root (required)                    - Root of the bundle
 #
 # Widgets:
 # * Unity Catalog: Text widget to input the name of the Unity Catalog
@@ -32,16 +33,13 @@
 # * Maximum chunk size: Maximum characters chunks will be split into
 # * Minimum chunk size: minimum characters chunks will be split into
 # * Chunk overlap: Overlap between chunks
+# * Root of bundle: Text widget to input the root of the bundle
 #
 # Usage:
 # 1. Set the appropriate values for the widgets.
 # 2. Run the pipeline to chunk the raw data and store in Unity Catalog.
 #
 ##################################################################################
-
-# COMMAND ----------
-
-# MAGIC %pip install -qqqq -r ../../../requirements.txt
 
 # COMMAND ----------
 
@@ -85,12 +83,12 @@ dbutils.widgets.text("min_chunk_size", "20", label="Minimum chunk size")
 # Chunk overlap
 dbutils.widgets.text("chunk_overlap", "50", label="Chunk overlap")
 
-# COMMAND ----------
-
-import os
-notebook_path =  '/Workspace/' + os.path.dirname(dbutils.notebook.entry_point.getDbutils().notebook().getContext().notebookPath().get())
-%cd $notebook_path
-%cd ../preprocessing
+# Bundle root
+dbutils.widgets.text(
+    "bundle_root",
+    "/",
+    label="Root of bundle",
+)
 
 # COMMAND ----------
 
@@ -103,6 +101,7 @@ hf_tokenizer_model = dbutils.widgets.get("hf_tokenizer_model")
 max_chunk_size = int(dbutils.widgets.get("max_chunk_size"))
 min_chunk_size = int(dbutils.widgets.get("min_chunk_size"))
 chunk_overlap = int(dbutils.widgets.get("chunk_overlap"))
+bundle_root = dbutils.widgets.get("bundle_root")
 
 assert uc_catalog != "", "uc_catalog notebook parameter must be specified"
 assert schema != "", "schema notebook parameter must be specified"
@@ -112,6 +111,13 @@ assert hf_tokenizer_model != "", "hf_tokenizer_model notebook parameter must be 
 assert max_chunk_size != "", "max_chunk_size notebook parameter must be specified"
 assert min_chunk_size != "", "min_chunk_size notebook parameter must be specified"
 assert chunk_overlap != "", "chunk_overlap notebook parameter must be specified"
+assert bundle_root != "", "bundle_root notebook parameter must be specified"
+
+# Updating to bundle root
+import sys 
+
+root = dbutils.widgets.get("bundle_root")
+sys.path.append(root)
 
 # COMMAND ----------
 
@@ -152,8 +158,7 @@ if not spark.catalog.tableExists(f"{preprocessed_data_table}") or spark.table(f"
 from functools import partial
 import pandas as pd
 from pyspark.sql.functions import pandas_udf
-from create_chunk import split_html_on_p
-
+from data_preparation.data_preprocessing.preprocessing.create_chunk import split_html_on_p
 
 @pandas_udf("array<string>")
 def parse_and_split(

--- a/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/data_preparation/vector_search/notebooks/VectorSearch.py.tmpl
+++ b/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/data_preparation/vector_search/notebooks/VectorSearch.py.tmpl
@@ -16,12 +16,14 @@
 # * schema (required)                         - Name of the schema inside Unity Catalog 
 # * preprocessed_data_table (required)        - Name of the preprocessed data table inside database of Unity Catalog
 # * vector_search_endpoint (required)         - Name of the Vector Search endpoint
+# * bundle_root (required)                    - Root of the bundle
 #
 # Widgets:
 # * Vector Search endpoint: Text widget to input the name of the Vector Search endpoint
 # * Unity Catalog: Text widget to input the name of the Unity Catalog
 # * Schema: Text widget to input the name of the database inside the Unity Catalog
 # * Preprocessed data table: Text widget to input the name of the preprocessed data table inside the database of Unity Catalog
+# * Root of bundle: Text widget to input the root of the bundle
 #
 # Usage:
 # 1. Set the appropriate values for the widgets.
@@ -29,10 +31,6 @@
 # 3. Create index.
 #
 ##################################################################################
-
-# COMMAND ----------
-
-# MAGIC %pip install -qqqq -r ../../../requirements.txt
 
 # COMMAND ----------
 
@@ -63,6 +61,12 @@ dbutils.widgets.text(
     "ai_agent_endpoint",
     label="Vector Search endpoint",
 )
+# Bundle root
+dbutils.widgets.text(
+    "bundle_root",
+    "/",
+    label="Root of bundle",
+)
 
 
 # COMMAND ----------
@@ -72,30 +76,30 @@ vector_search_endpoint = dbutils.widgets.get("vector_search_endpoint")
 uc_catalog = dbutils.widgets.get("uc_catalog")
 schema = dbutils.widgets.get("schema")
 preprocessed_data_table = dbutils.widgets.get("preprocessed_data_table")
+bundle_root = dbutils.widgets.get("bundle_root")
 
 assert vector_search_endpoint != "", "vector_search_endpoint notebook parameter must be specified"
 assert uc_catalog != "", "uc_catalog notebook parameter must be specified"
 assert schema != "", "schema notebook parameter must be specified"
 assert preprocessed_data_table != "", "preprocessed_data_table notebook parameter must be specified"
+assert bundle_root != "", "bundle_root notebook parameter must be specified"
 
-# COMMAND ----------
+# Updating to bundle root
+import sys 
 
-import os
-notebook_path =  '/Workspace/' + os.path.dirname(dbutils.notebook.entry_point.getDbutils().notebook().getContext().notebookPath().get())
-%cd $notebook_path
-%cd ../vector_search_utils
+root = dbutils.widgets.get("bundle_root")
+sys.path.append(root)
 
 # COMMAND ----------
 
 # DBTITLE 1,Initialize endpoint
 from databricks.vector_search.client import VectorSearchClient
-from utils import vs_endpoint_exists, wait_for_vs_endpoint_to_be_ready
+from data_preparation.vector_search.vector_search_utils.utils import vs_endpoint_exists, wait_for_vs_endpoint_to_be_ready
 
 vsc = VectorSearchClient(disable_notice=True)
 
 if not vs_endpoint_exists(vsc, vector_search_endpoint):
     vsc.create_endpoint(name=vector_search_endpoint, endpoint_type="STANDARD")
-
 
 # this may throw an error on the first pass, once the endpoint is created we'd see correct messages
 wait_for_vs_endpoint_to_be_ready(vsc, vector_search_endpoint)
@@ -104,7 +108,7 @@ print(f"Endpoint named {vector_search_endpoint} is ready.")
 # COMMAND ----------
 
 # DBTITLE 1,Create Index
-from utils import index_exists, wait_for_index_to_be_ready
+from data_preparation.vector_search.vector_search_utils.utils import index_exists, wait_for_index_to_be_ready
 from databricks.sdk import WorkspaceClient
 import databricks.sdk.service.catalog as c
 
@@ -131,14 +135,14 @@ else:
   #Trigger a sync to update our vs content with the new data saved in the table
   vsc.get_index(vector_search_endpoint, vs_index_fullname).sync()
 
-print(f"index {vs_index_fullname} on table {source_table_fullname} is ready")
+print(f"Index {vs_index_fullname} on table {source_table_fullname} is ready")
 
 # COMMAND ----------
 
 # DBTITLE 1,Test if Index Online
 import databricks 
 import time
-from utils import check_index_online
+from data_preparation.vector_search.vector_search_utils.utils import check_index_online
 
 vector_index=vsc.get_index(endpoint_name=vector_search_endpoint, index_name=vs_index_fullname)
 

--- a/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/data_preparation/vector_search/vector_search_utils/__init__.py.tmpl
+++ b/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/data_preparation/vector_search/vector_search_utils/__init__.py.tmpl
@@ -1,0 +1,17 @@
+"""Vector Search utilities for data preparation."""
+
+from .utils import (
+    vs_endpoint_exists,
+    wait_for_vs_endpoint_to_be_ready,
+    index_exists,
+    wait_for_index_to_be_ready,
+    check_index_online,
+)
+
+__all__ = [
+    "vs_endpoint_exists",
+    "wait_for_vs_endpoint_to_be_ready",
+    "index_exists", 
+    "wait_for_index_to_be_ready",
+    "check_index_online",
+]

--- a/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/resources/agent-resource.yml.tmpl
+++ b/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/resources/agent-resource.yml.tmpl
@@ -7,6 +7,9 @@ common_permissions: &permissions
 resources:
   jobs:
     agent_development_job:
+      parameters:
+        - name: bundle_root
+          default: ${workspace.file_path}
       name: ${bundle.target}-{{ .input_project_name }}-agent-development-job
       tasks:
         - task_key: AgentDevelopment
@@ -24,6 +27,7 @@ resources:
               model_alias: ${var.model_alias}
               # git source information of current ML resource deployment. It will be persisted as part of the workflow run
               git_source_info: url:${bundle.git.origin_url}; branch:${bundle.git.branch}; commit:${bundle.git.commit}
+          environment_key: agent_requirements
 
         - task_key: AgentEvaluation
           depends_on:
@@ -33,11 +37,13 @@ resources:
             base_parameters:
               uc_catalog: ${var.uc_catalog}
               schema: ${var.schema}
+              experiment: ${var.experiment}
               registered_model: ${var.registered_model}
               eval_table: ${var.eval_table}
               model_alias: ${var.model_alias}
               # git source information of current ML resource deployment. It will be persisted as part of the workflow run
               git_source_info: url:${bundle.git.origin_url}; branch:${bundle.git.branch}; commit:${bundle.git.commit}
+          environment_key: agent_requirements
 
         - task_key: AgentDeployment
           depends_on:
@@ -53,9 +59,19 @@ resources:
               workload_size: ${var.workload_size}
               # git source information of current ML resource deployment. It will be persisted as part of the workflow run
               git_source_info: url:${bundle.git.origin_url}; branch:${bundle.git.branch}; commit:${bundle.git.commit}
+          environment_key: agent_requirements
+
       schedule:
         quartz_cron_expression: "0 0 6 * * ?" # daily at 6am
         timezone_id: UTC
+        
+      environments:
+        - environment_key: agent_requirements
+          spec:
+            client: "3"
+            dependencies: 
+              - "-r /Workspace/Users/${workspace.current_user.userName}/.bundle/${bundle.name}/${bundle.target}/files/agent_development/agent_requirements.txt"
+
       <<: *permissions
       # If you want to turn on notifications for this job, please uncomment the below code,
       # and provide a list of emails to the on_failure argument.

--- a/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/resources/app-deployment-resource.yml.tmpl
+++ b/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/resources/app-deployment-resource.yml.tmpl
@@ -7,6 +7,9 @@ common_permissions: &permissions
 resources:
   jobs:
     app_deployment_job:
+      parameters:
+        - name: bundle_root
+          default: ${workspace.file_path}
       name: ${bundle.target}-{{ .input_project_name }}-app-deployment-job
       tasks:
         - task_key: AppDeployment

--- a/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/resources/data-preparation-resource.yml.tmpl
+++ b/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/resources/data-preparation-resource.yml.tmpl
@@ -7,6 +7,9 @@ common_permissions: &permissions
 resources:
   jobs:
     data_preprocessing_job:
+      parameters:
+        - name: bundle_root
+          default: ${workspace.file_path}
       name: ${bundle.target}-{{ .input_project_name }}-data-preprocessing-job
       tasks:
         - task_key: RawDataIngest
@@ -20,6 +23,7 @@ resources:
               data_source_url: https://docs.databricks.com/en/doc-sitemap.xml
               # git source information of current ML resource deployment. It will be persisted as part of the workflow run
               git_source_info: url:${bundle.git.origin_url}; branch:${bundle.git.branch}; commit:${bundle.git.commit}
+          environment_key: data_prep_requirements
 
         - task_key: PreprocessRawData
           depends_on:
@@ -38,6 +42,7 @@ resources:
               hf_tokenizer_model: ${var.hf_tokenizer_model}
               # git source information of current ML resource deployment. It will be persisted as part of the workflow run
               git_source_info: url:${bundle.git.origin_url}; branch:${bundle.git.branch}; commit:${bundle.git.commit}
+          environment_key: data_prep_requirements
 
         - task_key: VectorSearchIndex
           depends_on:
@@ -48,10 +53,19 @@ resources:
               # TODO modify these arguments to reflect your setup.
               uc_catalog: ${var.uc_catalog}
               schema: ${var.schema}
-              preprocessed_data_table_name: ${var.preprocessed_data_table}
+              preprocessed_data_table: ${var.preprocessed_data_table}
               vector_search_endpoint: ${var.vector_search_endpoint}
               # git source information of current ML resource deployment. It will be persisted as part of the workflow run
               git_source_info: url:${bundle.git.origin_url}; branch:${bundle.git.branch}; commit:${bundle.git.commit}
+          environment_key: data_prep_requirements
+
+      environments:
+        - environment_key: data_prep_requirements
+          spec:
+            client: "3"
+            dependencies: 
+              - "-r /Workspace/Users/${workspace.current_user.userName}/.bundle/${bundle.name}/${bundle.target}/files/data_preparation/data_prep_requirements.txt"
+
       schedule:
         quartz_cron_expression: "0 0 5 * * ?" # daily at 5am
         timezone_id: UTC


### PR DESCRIPTION
# Overview
minor changes to how dependencies are installed + how custom code is imported in the main notebooks. 

# Changes
## New bundle_root job parameter
- Used bundle_root (which is defined via the DAB as ${workspace.filePath}) in each job
- The bundle_root is then added to the path using `sys`, so we can import the util code without changing directory
- Updated __init__.py files where necessary. 
- Reason: creating unit tests/integration tests would fail because of the `$cd` keyword

## Defined environments in Jobs
- Each workflow now has an environment (using Serverless environment 3, as it is the latest)
- Added requirements.txt files as a dependency for each environment
- Now, pip installs + restarting is not necessary, so removed those cells. 

## Fixed parameter names
- For data preparation workflow, I used 'preprocessed_data_table_name' as the input var when the notebook actually used 'preprocessed_data_table'. Updated this to preprocessed_data_table 
- for agent evaluation task, experiment name was not passed. Corrected this. 
